### PR TITLE
Make all the mocha test functions available on global

### DIFF
--- a/lib/runtime/marionette.js
+++ b/lib/runtime/marionette.js
@@ -1,4 +1,18 @@
 var FilterData = require('./filterdata').FilterData;
+var mocha = require('mocha');
+global.afterEach = mocha.afterEach;
+global.after = mocha.after;
+global.beforeEach = mocha.beforeEach;
+global.before = mocha.before;
+global.describe = mocha.describe;
+global.it = mocha.it;
+global.setup = mocha.setup;
+global.suiteSetup = mocha.suiteSetup;
+global.suiteTeardown = mocha.suiteTeardown;
+global.suite = mocha.suite;
+global.teardown = mocha.teardown;
+global.test = mocha.test;
+
 
 /**
  * Internal method designed to attempt to find the metadata for this child


### PR DESCRIPTION
Fixes a problem where the runner does not start due to undefined functions.

```
ReferenceError: suite is not defined
at marionette (/home/CORPUSERS/23053085/Projects/album/client/node_modules/marionette-js-runner/lib/runtime/marionette.js:50:5)
at Object.<anonymous> (/home/CORPUSERS/23053085/Projects/base-app/smoke-tests/marionette-test.js:4:1)
```

Also, allows for writing test in a normal mocha fashion.
