### PR TITLE
Bug 1109157 - update our python packages

### DIFF
--- a/host/python/runner-service/setup.py
+++ b/host/python/runner-service/setup.py
@@ -11,8 +11,8 @@ except ImportError:
 
 PACKAGE_VERSION = '0.1'
 
-deps = ['mozrunner >= 6.5',
-        'mozprofile >= 0.21']
+deps = ['mozrunner == 6.6',
+        'mozprofile == 0.21']
 
 setup(name='gaia-runner-service',
       version=PACKAGE_VERSION,


### PR DESCRIPTION
This update pins the package versions we install for runner-service, and, whenever we call npm install, this will update our virtualenv. This virtualenv update feature is useful for local development (if we don't blow away our node_modules and use an npm linked one) and if we ever decide to unpin a package.
